### PR TITLE
Bug 577574 - Deprecate FileLocator.getBundleFile()

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Common Eclipse Runtime Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.common.tests;singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Automatic-Module-Name: org.eclipse.equinox.common.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.common.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.common.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.common.tests</artifactId>
-  <version>3.15.200-SNAPSHOT</version>
+  <version>3.15.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testClass>org.eclipse.equinox.common.tests.AllTests</testClass>

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/core/runtime/tests/FileLocatorTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/core/runtime/tests/FileLocatorTest.java
@@ -16,7 +16,6 @@ package org.eclipse.core.runtime.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -106,7 +105,6 @@ public class FileLocatorTest {
 
 		File file1 = FileLocator.getBundleFileLocation(bundle).get();
 		assertNotNull(file1);
-		assertSame(file1, FileLocator.getBundleFile(bundle));
 
 		URL fileURL = FileLocator
 				.toFileURL(context.getBundle().getEntry("Plugin_Testing/fileLocator/testFileLocatorGetRootFile"));
@@ -127,7 +125,6 @@ public class FileLocatorTest {
 
 		File file1 = FileLocator.getBundleFileLocation(bundle).get();
 		assertNotNull(file1);
-		assertSame(file1, FileLocator.getBundleFile(bundle));
 
 		URL fileURL = FileLocator
 				.toFileURL(context.getBundle().getEntry("Plugin_Testing/fileLocator/testFileLocatorGetRootFile.jar"));

--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
-Bundle-Version: 3.16.0.qualifier
+Bundle-Version: 3.16.100.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.resources,org.eclipse.pde.build",
  org.eclipse.core.internal.runtime;common=split;mandatory:=common;

--- a/bundles/org.eclipse.equinox.common/pom.xml
+++ b/bundles/org.eclipse.equinox.common/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.common</artifactId>
-  <version>3.16.0-SNAPSHOT</version>
+  <version>3.16.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/FileLocator.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/FileLocator.java
@@ -295,7 +295,9 @@ public final class FileLocator {
 	 * @throws IOException if an error occurs during the resolution
 	 * 
 	 * @since org.eclipse.equinox.common 3.4
+	 * @deprecated use {@link #getBundleFileLocation(Bundle)} instead
 	 */
+	@Deprecated(since = "3.16.100")
 	public static File getBundleFile(Bundle bundle) throws IOException {
 		return getBundleFileLocation(bundle)
 				.orElseThrow(() -> new IOException("Unable to locate the bundle file: " + bundle)); //$NON-NLS-1$


### PR DESCRIPTION
As discussed in [Bug 577574](https://bugs.eclipse.org/bugs/show_bug.cgi?id=577574) the existing method `FileLocator.getBundleFile()` should be deprecated in favor of the new method.