### PR TITLE
Update to Jetty 10.0.9

### DIFF
--- a/features/org.eclipse.equinox.server.jetty/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.server.jetty/forceQualifierUpdate.txt
@@ -48,3 +48,4 @@ Bug 574035 - Update to Jetty 10.0.4
 Bug 574035 - Update to Jetty 10.0.5-SNAPSHOT
 Bug 574035 - Update to Jetty 10.0.5
 Bug 575313 - Update to Jetty 10.0.6 
+Update to Jetty 10.0.9


### PR DESCRIPTION
Touch feature to pull latest deps.
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/187