### PR TITLE
build.properties still enforces Java 8 for

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/build.properties
+++ b/bundles/org.eclipse.equinox.preferences/build.properties
@@ -23,4 +23,3 @@ bin.includes = META-INF/,\
 src.includes = about.html,\
                schema/,\
                about_files/
-jre.compilation.profile = JavaSE-1.8


### PR DESCRIPTION
org.eclipse.equinox.preferences

BREE has changed a while ago to Java 11 so we should remove this
setting.