### PR TITLE
Remove load of unsupported legacy preference files

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/EclipsePreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/EclipsePreferences.java
@@ -364,7 +364,6 @@ public class EclipsePreferences implements IEclipsePreferences, IScope {
 			return result;
 		try {
 			result.setLoading(true);
-			result.loadLegacy();
 			result.load();
 			result.loaded();
 			result.flush();
@@ -730,10 +729,6 @@ public class EclipsePreferences implements IEclipsePreferences, IScope {
 		} else {
 			descriptor.loaded(absolutePath());
 		}
-	}
-
-	protected void loadLegacy() {
-		// sub-classes to over-ride if necessary
 	}
 
 	public static void log(IStatus status) {


### PR DESCRIPTION
As suggested by @vogella in PR #13 this PR suggests to remove the code to load legacy Eclipse 2.1 preference files that are not supported for a while.
I cannot tell since when those files were considered legacy but in the beginning of the git history of the `InstancePreferences` class 16 years ago they were already considered legacy. And I don't expect anybody to update from a more than 16year old Eclipse to a current one and to expect that it will work out of the box.
But somebody with a greater overview should make the decision to submit this or not.