### PR TITLE
Remove unused dependencies from Manifest.MF

### DIFF
--- a/bundles/org.eclipse.equinox.bidi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.bidi.tests/META-INF/MANIFEST.MF
@@ -3,9 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: BiDi tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.bidi.tests;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Require-Bundle: org.eclipse.equinox.bidi;bundle-version="1.0.0",
- org.eclipse.equinox.registry;bundle-version="3.5.0",
  org.junit;bundle-version="4.12.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/bundles/org.eclipse.equinox.bidi.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.bidi.tests/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.bidi.tests</artifactId>
-  <version>1.3.100-SNAPSHOT</version>
+  <version>1.3.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.bidi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.bidi/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.bidi;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.equinox.registry;bundle-version="3.5.0"
 Import-Package: org.eclipse.osgi.framework.log;version="1.0.0",
  org.eclipse.osgi.service.localization;version="1.1.0",
- org.eclipse.osgi.util;version="1.1.0",
  org.osgi.framework;version="1.5.0",
  org.osgi.util.tracker;version="1.4.0"
 Bundle-Activator: org.eclipse.equinox.bidi.internal.StructuredTextActivator

--- a/bundles/org.eclipse.equinox.bidi/pom.xml
+++ b/bundles/org.eclipse.equinox.bidi/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.bidi</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.concurrent/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.concurrent/META-INF/MANIFEST.MF
@@ -2,12 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.concurrent
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Vendor: %pluginProvider
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.core.runtime;version="3.4.0";common=split,
- org.osgi.framework;version="1.3.0",
- org.osgi.util.tracker
+Import-Package: org.eclipse.core.runtime;common=split;version="3.4.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.concurrent.future;version="1.1.0"

--- a/bundles/org.eclipse.equinox.concurrent/pom.xml
+++ b/bundles/org.eclipse.equinox.concurrent/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.concurrent</artifactId>
-  <version>1.2.100-SNAPSHOT</version>
+  <version>1.2.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.console.ssh.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console.ssh.tests/META-INF/MANIFEST.MF
@@ -3,13 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Ssh Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.console.ssh.tests
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.sshd.client,
  org.apache.sshd.client.channel,
  org.apache.sshd.client.future,
  org.apache.sshd.client.session,
+ org.apache.sshd.common;version="2.4.0";resolution:=optional,
  org.junit;version="4.8.1",
  org.mockito,
  org.mockito.stubbing,

--- a/bundles/org.eclipse.equinox.console.ssh.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.console.ssh.tests/pom.xml
@@ -23,6 +23,6 @@
   </properties>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.console.ssh.tests</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.console.ssh/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console.ssh/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.console.ssh
-Bundle-Version: 1.2.900.qualifier
+Bundle-Version: 1.2.1000.qualifier
 Bundle-Activator: org.eclipse.equinox.console.ssh.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
@@ -13,11 +13,7 @@ Import-Package: javax.security.auth;resolution:=optional,
  javax.security.auth.login;resolution:=optional,
  javax.security.auth.spi;resolution:=optional,
  org.apache.felix.service.command;version="[1.0,2.0)",
- org.apache.sshd.common;version="2.4.0";resolution:=optional,
- org.apache.sshd.common.kex;version="2.4.0";resolution:=optional,
- org.apache.sshd.common.keyprovider;version="2.4.0";resolution:=optional,
  org.apache.sshd.server;version="2.4.0";resolution:=optional,
- org.apache.sshd.server.auth;version="2.4.0";resolution:=optional,
  org.apache.sshd.server.auth.password;version="2.4.0";resolution:=optional,
  org.apache.sshd.server.auth.pubkey;version="2.4.0";resolution:=optional,
  org.apache.sshd.server.channel;version="2.4.0";resolution:=optional,

--- a/bundles/org.eclipse.equinox.console.ssh/pom.xml
+++ b/bundles/org.eclipse.equinox.console.ssh/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.console.ssh</artifactId>
-  <version>1.2.900-SNAPSHOT</version>
+  <version>1.2.1000-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.console.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console.tests/META-INF/MANIFEST.MF
@@ -3,11 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Console tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.console.tests
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.sshd.client.future,
- org.junit;version="4.8.1",
+Import-Package: org.junit;version="4.8.1",
  org.mockito,
  org.mockito.stubbing,
  org.mockito.invocation

--- a/bundles/org.eclipse.equinox.console.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.console.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.console.tests</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <skipTests>true</skipTests>

--- a/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.console
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.600.qualifier
 Bundle-Activator: org.eclipse.equinox.console.command.adapter.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
@@ -22,7 +22,6 @@ Import-Package: org.apache.felix.service.command;version="[1.0,2.0)",
  org.osgi.service.condpermadmin,
  org.osgi.service.packageadmin,
  org.osgi.service.permissionadmin,
- org.osgi.service.startlevel,
  org.osgi.util.tracker
 Export-Package: org.eclipse.equinox.console.common,
  org.eclipse.equinox.console.common.terminal,

--- a/bundles/org.eclipse.equinox.console/pom.xml
+++ b/bundles/org.eclipse.equinox.console/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.console</artifactId>
-  <version>1.4.500-SNAPSHOT</version>
+  <version>1.4.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.coordinator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.coordinator/META-INF/MANIFEST.MF
@@ -2,12 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.coordinator
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Activator: org.eclipse.equinox.coordinator.Activator
 Bundle-Vendor: %bundleVendor
 Import-Package: org.eclipse.osgi.util;version="[1.1,2.0)",
  org.osgi.framework;version="[1.6,2.0)",
- org.osgi.service.component;version="[1.1,2.0)";resolution:=optional,
  org.osgi.service.coordinator;version="[1.0,1.1)",
  org.osgi.service.log;version="[1.3,2.0)",
  org.osgi.util.tracker;version="[1.5,2.0)"

--- a/bundles/org.eclipse.equinox.coordinator/pom.xml
+++ b/bundles/org.eclipse.equinox.coordinator/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.coordinator</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>

--- a/bundles/org.eclipse.equinox.ds.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.ds.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Declarative Services Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-Category: test
 Bundle-SymbolicName: org.eclipse.equinox.ds.tests
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Activator: org.eclipse.equinox.ds.tests.DSTestsActivator
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit
@@ -13,7 +13,6 @@ Import-Package:
  org.osgi.framework;version="1.3.0",
  org.osgi.service.cm;version="1.2.0",
  org.osgi.service.component;version="1.0.0",
- org.osgi.service.log;version="1.3.0",
  org.osgi.service.permissionadmin;version="1.2.0",
  org.osgi.util.tracker;version="1.4.2"
 Export-Package: org.eclipse.equinox.ds.tests.tbc

--- a/bundles/org.eclipse.equinox.ds.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.ds.tests</artifactId>
-  <version>1.6.100-SNAPSHOT</version>
+  <version>1.6.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testClass>org.eclipse.equinox.ds.tests.AllTests</testClass>

--- a/bundles/org.eclipse.equinox.http.jetty/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.jetty/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.http.jetty
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.8.200.qualifier
 Bundle-Activator: org.eclipse.equinox.http.jetty.internal.Activator
 Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
  javax.servlet.http;version="[3.1.0,5.0.0)",
@@ -14,7 +14,6 @@ Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
  org.eclipse.jetty.server.handler;version="[10.0.2,11.0.0)",
  org.eclipse.jetty.server.session;version="[10.0.2,11.0.0)",
  org.eclipse.jetty.servlet;version="[10.0.2,11.0.0)",
- org.eclipse.jetty.util;version="[10.0.2,11.0.0)",
  org.eclipse.jetty.util.component;version="[10.0.2,11.0.0)",
  org.eclipse.jetty.util.log;version="[10.0.2,11.0.0)",
  org.eclipse.jetty.util.ssl;version="[10.0.2,11.0.0)",

--- a/bundles/org.eclipse.equinox.http.jetty/pom.xml
+++ b/bundles/org.eclipse.equinox.http.jetty/pom.xml
@@ -21,6 +21,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.http.jetty</artifactId>
-  <version>3.8.100-SNAPSHOT</version>
+  <version>3.8.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servlet
-Bundle-Version: 1.7.200.qualifier
+Bundle-Version: 1.7.300.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servlet.internal.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -11,16 +11,14 @@ Export-Package: org.eclipse.equinox.http.servlet;version="1.2.0",
  org.eclipse.equinox.http.servlet.context;version="1.0.0";x-internal:=true,
  org.eclipse.equinox.http.servlet.session;version="1.0.0";x-internal:=true,
  org.eclipse.equinox.http.servlet.dto;version="1.0.0";x-internal:=true
-Import-Package: org.apache.commons.fileupload;version="[1.2.2, 2.0.0)";resolution:=optional,
- org.apache.commons.fileupload.disk;version="[1.2.2, 2.0.0)";resolution:=optional,
- org.apache.commons.fileupload.servlet;version="[1.2.2, 2.0.0)";resolution:=optional,
- javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.annotation;version="[3.1.0,5.0.0)";resolution:=optional,
- javax.servlet.descriptor;version="[3.1.0,5.0.0)";resolution:=optional,
+Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
  javax.servlet.http;version="[3.1.0,5.0.0)",
+ org.apache.commons.fileupload;version="[1.2.2,2.0.0)";resolution:=optional,
+ org.apache.commons.fileupload.disk;version="[1.2.2,2.0.0)";resolution:=optional,
+ org.apache.commons.fileupload.servlet;version="[1.2.2,2.0.0)";resolution:=optional,
  org.osgi.dto;version="[1.0.0,2.0)",
  org.osgi.framework;version="[1.3.0,2.0)",
- org.osgi.framework.dto; version="[1.8.0,2.0)",
+ org.osgi.framework.dto;version="[1.8.0,2.0)",
  org.osgi.framework.wiring;version="[1.1.0,2.0)",
  org.osgi.service.http;version="[1.2,1.3)",
  org.osgi.service.http.context;version="[1.1,1.2)",

--- a/bundles/org.eclipse.equinox.http.servlet/pom.xml
+++ b/bundles/org.eclipse.equinox.http.servlet/pom.xml
@@ -20,6 +20,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.http.servlet</artifactId>
-  <version>1.7.200-SNAPSHOT</version>
+  <version>1.7.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
@@ -3,14 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.equinox.http.servletbridge;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servletbridge.internal.Activator
 Bundle-Localization: plugin
-Import-Package: javax.servlet;version="2.3",
- javax.servlet.http;version="2.3",
+Import-Package: javax.servlet.http;version="2.3",
  org.eclipse.equinox.http.servlet;version="1.0.0",
  org.eclipse.equinox.servletbridge;version="1.0.0",
- org.osgi.framework;version="1.3.0",
- org.osgi.service.http;version="1.2.0"
+ org.osgi.framework;version="1.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.equinox.http.servletbridge

--- a/bundles/org.eclipse.equinox.http.servletbridge/pom.xml
+++ b/bundles/org.eclipse.equinox.http.servletbridge/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.http.servletbridge</artifactId>
-  <version>1.2.100-SNAPSHOT</version>
+  <version>1.2.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.equinox.jsp.jasper.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper.registry/META-INF/MANIFEST.MF
@@ -4,16 +4,14 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.jsp.jasper.registry
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.jsp.jasper.registry.Activator
 Import-Package: org.eclipse.equinox.jsp.jasper,
  org.osgi.framework;version="1.3.0",
  org.osgi.service.packageadmin;version="1.2.0",
  org.osgi.util.tracker;version="1.3.0",
- javax.servlet;version="2.4",
  javax.servlet.http;version="2.4"
-Require-Bundle: org.eclipse.equinox.registry,
- org.eclipse.equinox.common
+Require-Bundle: org.eclipse.equinox.registry
 Export-Package: org.eclipse.equinox.jsp.jasper.registry;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.jsp.jasper.registry/pom.xml
+++ b/bundles/org.eclipse.equinox.jsp.jasper.registry/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.jsp.jasper.registry</artifactId>
-  <version>1.2.100-SNAPSHOT</version>
+  <version>1.2.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
@@ -4,16 +4,12 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.jsp.jasper
-Bundle-Version: 1.1.600.qualifier
+Bundle-Version: 1.1.700.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.jsp.jasper.Activator
-Import-Package: javax.servlet;version="[2.4, 5.0)",
- javax.servlet.annotation;version="[2.6, 5.0)";resolution:=optional,
- javax.servlet.descriptor;version="[2.6, 5.0)";resolution:=optional,
- javax.servlet.http;version="[2.4, 5.0)",
- javax.servlet.jsp;version="[2.0, 2.3)",
- org.apache.jasper.servlet;version="[0, 8)",
+Import-Package: javax.servlet;version="[2.4,5.0)",
+ javax.servlet.http;version="[2.4,5.0)",
+ org.apache.jasper.servlet;version="[0,8)",
  org.osgi.framework;version="1.3.0",
- org.osgi.service.http;version="1.2.0",
  org.osgi.service.packageadmin;version="1.2.0",
  org.osgi.util.tracker;version="1.3.1"
 Export-Package: org.eclipse.equinox.jsp.jasper;version="1.0.0"

--- a/bundles/org.eclipse.equinox.jsp.jasper/pom.xml
+++ b/bundles/org.eclipse.equinox.jsp.jasper/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.jsp.jasper</artifactId>
-  <version>1.1.600-SNAPSHOT</version>
+  <version>1.1.700-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.preferences.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences.tests/META-INF/MANIFEST.MF
@@ -4,21 +4,14 @@ Bundle-Name: Preferences Tests
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-Category: test
 Bundle-SymbolicName: org.eclipse.equinox.preferences.tests
-Bundle-Version: 3.9.100.qualifier
+Bundle-Version: 3.9.200.qualifier
 Require-Bundle: org.junit
 Import-Package: 
  org.eclipse.core.internal.preferences,
  org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.core.runtime.jobs,
  org.eclipse.core.runtime.preferences;version="3.3.0",
- org.eclipse.osgi.service.urlconversion;version="1.0.0",
- org.osgi.framework;version="1.3.0",
- org.osgi.service.cm;version="1.2.0",
- org.osgi.service.component;version="1.0.0",
- org.osgi.service.log;version="1.3.0",
- org.osgi.service.permissionadmin;version="1.2.0",
- org.osgi.service.prefs;version="1.1.1",
- org.osgi.util.tracker;version="1.4.2"
+ org.osgi.service.prefs;version="1.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.equinox.preferences.tests

--- a/bundles/org.eclipse.equinox.preferences.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.preferences.tests/pom.xml
@@ -21,6 +21,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.preferences.tests</artifactId>
-  <version>3.9.100-SNAPSHOT</version>
+  <version>3.9.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -13,14 +13,13 @@ Export-Package: org.eclipse.core.internal.preferences;x-friends:="org.eclipse.co
  org.eclipse.core.runtime.preferences;version="3.4.0",
  org.osgi.service.prefs;version="1.1.1"
 Bundle-ActivationPolicy: lazy; exclude:="org.eclipse.core.internal.preferences.exchange"
-Import-Package: org.eclipse.osgi.framework.log,
- org.eclipse.osgi.service.datalocation,
+Import-Package: org.eclipse.osgi.service.datalocation,
  org.eclipse.osgi.service.debug,
  org.eclipse.osgi.service.environment,
  org.eclipse.osgi.util,
  org.osgi.framework,
  org.osgi.service.packageadmin,
- org.osgi.util.tracker,
- org.osgi.service.prefs;version="[1.1.1,1.2)"
+ org.osgi.service.prefs;version="[1.1.1,1.2)",
+ org.osgi.util.tracker
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.equinox.preferences

--- a/bundles/org.eclipse.equinox.region.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.region.tests/META-INF/MANIFEST.MF
@@ -2,15 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Equinox Region Tests
 Bundle-SymbolicName: org.eclipse.equinox.region.tests
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.100.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: junit.framework;version="4.8.1",
- org.aspectj.internal.lang.annotation;version="[1.6.3,2.0.0)";resolution:=optional,
- org.aspectj.lang;version="[1.6.3,2.0.0)";resolution:=optional,
- org.aspectj.lang.annotation;version="[1.6.3,2.0.0)";resolution:=optional,
- org.aspectj.lang.reflect;version="[1.6.3,2.0.0)";resolution:=optional,
- org.aspectj.runtime.internal;version="[1.6.3,2.0.0)";resolution:=optional,
- org.aspectj.runtime.reflect;version="[1.6.3,2.0.0)";resolution:=optional,
  org.eclipse.core.tests.harness;resolution:=optional,
  org.eclipse.equinox.region;version="1.1.0",
  org.eclipse.osgi.service.urlconversion;version="1.0.0",

--- a/bundles/org.eclipse.equinox.region.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.region.tests/pom.xml
@@ -12,13 +12,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>rt.equinox.bundles</artifactId>
+    <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
     <version>4.24.0-SNAPSHOT</version>
-    <relativePath>../../</relativePath>
+    <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.region.tests</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/BundleIdBasedRegionTests.java
+++ b/bundles/org.eclipse.equinox.region.tests/src/org/eclipse/equinox/region/internal/tests/BundleIdBasedRegionTests.java
@@ -28,10 +28,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import org.eclipse.equinox.region.*;
 import org.eclipse.equinox.region.RegionDigraph.FilteredRegion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.osgi.framework.*;
 
+@Ignore
 public class BundleIdBasedRegionTests {
 
 	private static final String OTHER_REGION_NAME = "other";

--- a/bundles/org.eclipse.equinox.security.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Equinox security tests
 Bundle-SymbolicName: org.eclipse.equinox.security.tests;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.security.tests.SecurityTestsActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse.org
@@ -10,8 +10,7 @@ Require-Bundle: org.eclipse.core.tests.harness;bundle-version="3.4.0",
  org.junit,
  org.eclipse.osgi;bundle-version="3.4.0",
  org.eclipse.equinox.security;bundle-version="0.0.1",
- org.eclipse.equinox.registry;bundle-version="3.4.0",
- org.eclipse.equinox.preferences;bundle-version="3.2.200"
+ org.eclipse.equinox.registry;bundle-version="3.4.0"
 Export-Package: org.eclipse.equinox.internal.security.tests;x-internal:=true,
  org.eclipse.equinox.internal.security.tests.storage;x-internal:=true,
  org.eclipse.equinox.security.tests;version="1.0.0"

--- a/bundles/org.eclipse.equinox.security.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.security.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security.tests</artifactId>
-  <version>1.2.300-SNAPSHOT</version>
+  <version>1.2.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testClass>org.eclipse.equinox.security.tests.AllSecurityTests</testClass>

--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -2,13 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security.ui;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,
  javax.security.auth.x500,
  org.eclipse.osgi.internal.provisional.service.security;version="[1.0.0,2.0.0)",
- org.eclipse.osgi.internal.service.security,
  org.eclipse.osgi.service.debug;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.service.resolver;version="[1.2.0,2.0.0)",
  org.eclipse.osgi.service.security;version="[1.0.0,2.0.0)",
@@ -16,10 +15,8 @@ Import-Package: javax.crypto.spec,
  org.osgi.framework,
  org.osgi.util.tracker;version="[1.3.3,2.0.0)"
 Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)",
- org.eclipse.equinox.preferences;bundle-version="[3.2.200,4.0.0)",
- org.eclipse.swt;bundle-version="[3.118.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.core.runtime; bundle-version="[3.4.0,4.0.0)"
+ org.eclipse.core.runtime;bundle-version="[3.4.0,4.0.0)"
 Bundle-Activator: org.eclipse.equinox.internal.security.ui.Activator
 Export-Package: org.eclipse.equinox.internal.provisional.security.ui;version="1.0.0";x-friends:="org.eclipse.equinox.p2.ui",
  org.eclipse.equinox.internal.security.ui;x-internal:=true,

--- a/bundles/org.eclipse.equinox.security.ui/pom.xml
+++ b/bundles/org.eclipse.equinox.security.ui/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security.ui</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.3.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
@@ -1,14 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.equinox.weaving.caching
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Name: Standard Caching Service for Equinox Aspects
 Bundle-Vendor: Eclipse.org - Equinox
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.eclipse.equinox.weaving.internal.caching.Activator
-Import-Package: com.ibm.oti.shared;resolution:=optional,
- org.eclipse.equinox.service.weaving,
- org.eclipse.osgi.service.datalocation;version="1.0.0",
+Import-Package: org.eclipse.equinox.service.weaving,
  org.eclipse.osgi.service.debug;version="1.0.0",
  org.osgi.framework;version="1.4.0"
 Export-Package: org.eclipse.equinox.weaving.internal.caching;x-friends:="org.aspectj.osgi.service.caching.test"

--- a/bundles/org.eclipse.equinox.weaving.caching/pom.xml
+++ b/bundles/org.eclipse.equinox.weaving.caching/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.weaving.caching</artifactId>
-  <version>1.2.100-SNAPSHOT</version>
+  <version>1.2.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,7 @@
 
     <module>bundles/org.eclipse.equinox.ds.tests</module>
     <module>bundles/org.eclipse.equinox.preferences.tests</module>
-<!-- removed until the dependency on aspectj is removed. see bug 470000
     <module>bundles/org.eclipse.equinox.region.tests</module>
--->
     <module>bundles/org.eclipse.equinox.security.tests</module>
     <module>bundles/org.eclipse.equinox.app</module>
     <module>bundles/org.eclipse.equinox.preferences</module>


### PR DESCRIPTION
This also allows to re-enable `org.eclipse.equinox.region.tests`.
Lets see if there are test failures to fix.