### PR TITLE
[Features] Leaverage transitive inclusion and build source-features

### DIFF
--- a/features/org.eclipse.equinox.core.feature/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.core.feature/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ Touch feature for I20180903-0800 failure due to new felix.scr qualifier.
 Bug 551174 - Comparator errors in 4.14 I build - I20190917-1800
 Bug 544571 - Update felix SCR to 2.0.16
 4.19 I-Build: I20210204-0900 - BUILD FAILED
+[Features] Leverage transitive inclusion and build source-features: https://github.com/eclipse-equinox/equinox.bundles/pull/20

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -19,62 +19,13 @@
       %license
    </license>
 
-   <plugin
-         id="org.eclipse.osgi"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+   <includes
+         id="org.eclipse.equinox.core.feature"
+         version="0.0.0"/>
 
-   <plugin
-         id="org.eclipse.osgi.compatibility.state"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi.compatibility.state.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi.services"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi.services.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.common"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.common.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+   <includes
+         id="org.eclipse.equinox.core.feature.source"
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.equinox.launcher"
@@ -85,20 +36,6 @@
 
    <plugin
          id="org.eclipse.equinox.launcher.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.registry"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.registry.source"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -149,20 +86,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.osgi.util"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.osgi.util.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.concurrent"
          download-size="0"
          install-size="0"
@@ -171,20 +94,6 @@
 
    <plugin
          id="org.eclipse.equinox.concurrent.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.simpleconfigurator"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.simpleconfigurator.source"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -302,20 +211,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.equinox.console"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.console.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.console.ssh"
          download-size="0"
          install-size="0"
@@ -335,48 +230,6 @@
          install-size="0"
          version="0.0.0"
          fragment="true"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.command"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.command.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.runtime"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.runtime.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.shell"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.felix.gogo.shell.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
          unpack="false"/>
 
    <plugin

--- a/features/org.eclipse.equinox.sdk/feature.xml
+++ b/features/org.eclipse.equinox.sdk/feature.xml
@@ -35,8 +35,4 @@
          id="org.eclipse.equinox.executable"
          version="0.0.0"/>
 
-   <includes
-         id="org.eclipse.equinox.core.feature"
-         version="0.0.0"/>
-
 </feature>

--- a/features/org.eclipse.equinox.server.core/.project
+++ b/features/org.eclipse.equinox.server.core/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.equinox.server.core.feature</name>
+	<name>org.eclipse.equinox.server.core</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/features/org.eclipse.equinox.server.jetty/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.server.jetty/forceQualifierUpdate.txt
@@ -49,3 +49,4 @@ Bug 574035 - Update to Jetty 10.0.5-SNAPSHOT
 Bug 574035 - Update to Jetty 10.0.5
 Bug 575313 - Update to Jetty 10.0.6 
 Update to Jetty 10.0.9
+[Features] Leverage transitive inclusion and build source-features: https://github.com/eclipse-equinox/equinox.bundles/pull/20

--- a/features/org.eclipse.equinox.server.p2/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.server.p2/forceQualifierUpdate.txt
@@ -23,3 +23,4 @@ Bug 528810 - Compilation failure in I20171214-2000
 Bug 444188 - EclipsePreferences is not thread safe
 Bug 553238 - Unanticipated comparator errors in I20191119-1800
 Bug 568610 - 4.18 I-Build: I20201106-1800 - BUILD FAILED
+[Features] Leverage transitive inclusion and build source-features: https://github.com/eclipse-equinox/equinox.bundles/pull/20

--- a/features/org.eclipse.equinox.serverside.sdk/feature.xml
+++ b/features/org.eclipse.equinox.serverside.sdk/feature.xml
@@ -24,19 +24,24 @@
          version="0.0.0"/>
 
    <includes
+         id="org.eclipse.equinox.server.core.source"
+         version="0.0.0"/>
+
+   <includes
          id="org.eclipse.equinox.server.jetty"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.equinox.server.jetty.source"
          version="0.0.0"/>
 
    <includes
          id="org.eclipse.equinox.server.p2"
          version="0.0.0"/>
 
-   <plugin
-         id="jakarta.servlet-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+   <includes
+         id="org.eclipse.equinox.server.p2.source"
+         version="0.0.0"/>
 
    <plugin
          id="javax.servlet.jsp"
@@ -53,13 +58,6 @@
          unpack="false"/>
 
    <plugin
-         id="jakarta.servlet-api.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="javax.el"
          download-size="0"
          install-size="0"
@@ -68,48 +66,6 @@
 
    <plugin
          id="javax.el.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.jetty"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.jetty.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.registry"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.registry.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.servlet"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.equinox.http.servlet.source"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -152,104 +108,6 @@
 
    <plugin
          id="org.apache.jasper.glassfish.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.http"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.http.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.io"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.io.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.security"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.security.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.server"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.server.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.servlet"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.servlet.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.util"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.util.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.util.ajax"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.jetty.util.ajax.source"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -112,5 +112,35 @@
     <module>bundles/org.eclipse.equinox.weaving.caching.j9</module>
     <module>bundles/org.eclipse.equinox.weaving.hook</module>
   </modules>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>feature-source</id>
+            <goals>
+              <goal>feature-source</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-p2-metadata</id>
+            <phase>package</phase>
+            <goals>
+              <goal>p2-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
This PR proposes to build source-features for all non-sdk features of equinox-bundles and to simplify the feature content by leveraging transitive inclusion and the now generated source features.

Leveraging transitive inclusion avoids effective duplicates and reduces the maintenance effort. Furthermore it becomes more unlikely to forget to include a source-plugin. My intention is also to reduce the subsequent maintenance effort of https://github.com/eclipse-equinox/equinox.framework/pull/41.

Besides that, it removes the `.feature` suffix from the project-name `org.eclipse.equinox.server.core.feature` to match the feature name.