### PR TITLE
Add OSGi app, coordinator and stream bundles to features

### DIFF
--- a/features/org.eclipse.equinox.compendium.sdk/feature.xml
+++ b/features/org.eclipse.equinox.compendium.sdk/feature.xml
@@ -145,4 +145,18 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.osgi.service.coordinator"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.coordinator.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/org.eclipse.equinox.core.sdk/feature.xml
+++ b/features/org.eclipse.equinox.core.sdk/feature.xml
@@ -317,4 +317,32 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.osgi.service.log.stream"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.log.stream.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.util.pushstream"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.util.pushstream.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This PR adds the OSGi-bundles that replace the formerly embedded OSGi source-code in `org.eclipse.equinox.app`, `org.eclipse.equinox.coordinator`, `org.eclipse.equinox.log.stream` to those Features that contain the Plug-ins whose OSGi-sources are replaced.
The motivation to add the OSGi-bundles to the features is mainly to also have their sources included into the p2-repos of the Eclipse-SDK.

This is part of https://github.com/eclipse-equinox/equinox.framework/issues/40 and should be submitted after https://github.com/eclipse-equinox/equinox.bundles/pull/26 is merged.