### PR TITLE
Add missing Package-Import of org.osgi.util.function

### DIFF
--- a/bundles/org.eclipse.equinox.log.stream/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.log.stream/META-INF/MANIFEST.MF
@@ -3,13 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Vendor: %bundleVendor
 Bundle-SymbolicName: org.eclipse.equinox.log.stream
-Bundle-Version: 1.0.400.qualifier
+Bundle-Version: 1.0.500.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.log.stream.LogStreamManager
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
 Import-Package: org.osgi.framework;version="[1.9.0,2.0.0)",
  org.osgi.service.log;version="[1.4.0,2.0.0)",
  org.osgi.service.log.stream;version="[1.0,1.1)",
+ org.osgi.util.function;version="[1.1.0,2.0.0)",
  org.osgi.util.promise;version="[1.0.0,2.0.0)",
  org.osgi.util.pushstream;version="[1.0,1.1)",
  org.osgi.util.tracker;version="[1.5.0,2.0.0)"

--- a/bundles/org.eclipse.equinox.log.stream/pom.xml
+++ b/bundles/org.eclipse.equinox.log.stream/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.log.stream</artifactId>
-  <version>1.0.400-SNAPSHOT</version>
+  <version>1.0.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>


### PR DESCRIPTION
Attempt to fix the compilation error in the current I-Build: https://ci.eclipse.org/releng/job/I-build-4.24/87

Without this change I have a very similar compilation error in `org.osgi.util.pushstream.AbstractPushStreamImpl` like in the one causing the build failure. That class is in the same bundle like the failing `org/eclipse/equinox/internal/log/stream/LogStreamProviderFactory`.

@sravanlakkimsetti this could help in case the I-build fails again.

