### PR TITLE
 POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.equinox.app/pom.xml
+++ b/bundles/org.eclipse.equinox.app/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.cm.test/pom.xml
+++ b/bundles/org.eclipse.equinox.cm.test/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/bundles/org.eclipse.equinox.common.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.common.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.compendium.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.compendium.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.console.ssh.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.console.ssh.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <properties>

--- a/bundles/org.eclipse.equinox.console.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.console.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.device/pom.xml
+++ b/bundles/org.eclipse.equinox.device/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.ds.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.ds.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.http.servlet.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.metatype/pom.xml
+++ b/bundles/org.eclipse.equinox.metatype/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.security.linux/pom.xml
+++ b/bundles/org.eclipse.equinox.security.linux/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.security.macosx/pom.xml
+++ b/bundles/org.eclipse.equinox.security.macosx/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.security.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.security.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>tests-pom</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../tests-pom/</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.security.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.equinox.security.win32.x86_64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.security/pom.xml
+++ b/bundles/org.eclipse.equinox.security/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.slf4j.stub/pom.xml
+++ b/bundles/org.eclipse.equinox.slf4j.stub/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/bundles/org.eclipse.equinox.useradmin/pom.xml
+++ b/bundles/org.eclipse.equinox.useradmin/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <properties>

--- a/bundles/org.eclipse.equinox.weaving.caching.j9/pom.xml
+++ b/bundles/org.eclipse.equinox.weaving.caching.j9/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.weaving.caching/pom.xml
+++ b/bundles/org.eclipse.equinox.weaving.caching/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.bundles</artifactId>
     <groupId>org.eclipse.equinox.bundles</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/tests-pom/pom.xml
+++ b/tests-pom/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.eclipse.equinox.bundles</groupId>
     <artifactId>rt.equinox.bundles</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>tests-pom</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release