### PR TITLE
Incorrect org.osgi.service.prefs dependency in

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.preferences; singleton:=true
-Bundle-Version: 3.10.0.qualifier
+Bundle-Version: 3.10.1.qualifier
 Bundle-Activator: org.eclipse.core.internal.preferences.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.preferences/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.preferences/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
+Incorrect org.osgi.service.prefs dependency in org.eclipse.equinox.preferences-3.10.0 #54


### PR DESCRIPTION
org.eclipse.equinox.preferences-3.10.0 #54

Tracked in https://github.com/eclipse-equinox/equinox.bundles/issues/54