### PR TITLE
UpdateJetty to 9.4.48

### DIFF
--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.10.203.qualifier"
+      version="1.10.204.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.jetty/pom.xml
+++ b/features/org.eclipse.equinox.server.jetty/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.equinox.feature</groupId>
   <artifactId>org.eclipse.equinox.server.jetty</artifactId>
-  <version>1.10.203-SNAPSHOT</version>
+  <version>1.10.204-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>


### PR DESCRIPTION
Tracked in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/368