### PR TITLE
back-port: use stronger cipher for secure storage

### DIFF
--- a/bundles/org.eclipse.equinox.security.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Equinox security tests
 Bundle-SymbolicName: org.eclipse.equinox.security.tests;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.301.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.security.tests.SecurityTestsActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse.org

--- a/bundles/org.eclipse.equinox.security.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.security.tests/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security.tests</artifactId>
-  <version>1.2.300-SNAPSHOT</version>
+  <version>1.2.301-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testClass>org.eclipse.equinox.security.tests.AllSecurityTests</testClass>

--- a/bundles/org.eclipse.equinox.security.tests/src/org/eclipse/equinox/internal/security/tests/storage/SecurePreferencesTest.java
+++ b/bundles/org.eclipse.equinox.security.tests/src/org/eclipse/equinox/internal/security/tests/storage/SecurePreferencesTest.java
@@ -419,7 +419,7 @@ abstract public class SecurePreferencesTest extends StorageAbstractTest {
 			try {
 				node.get("password1", "default");
 			} catch (StorageException e) {
-				assertEquals(StorageException.DECRYPTION_ERROR, e.getErrorCode());
+				assertEquals(StorageException.INTERNAL_ERROR, e.getErrorCode());
 				exception = true;
 			}
 			assertTrue(exception);
@@ -428,7 +428,7 @@ abstract public class SecurePreferencesTest extends StorageAbstractTest {
 			try {
 				node.get("password2", "default");
 			} catch (StorageException e) {
-				assertEquals(StorageException.DECRYPTION_ERROR, e.getErrorCode());
+				assertEquals(StorageException.INTERNAL_ERROR, e.getErrorCode());
 				exception = true;
 			}
 			assertTrue(exception);
@@ -452,7 +452,7 @@ abstract public class SecurePreferencesTest extends StorageAbstractTest {
 			try {
 				node.get("password", "default");
 			} catch (StorageException e) {
-				assertEquals(StorageException.DECRYPTION_ERROR, e.getErrorCode());
+				assertEquals(StorageException.INTERNAL_ERROR, e.getErrorCode());
 				exception = true;
 			}
 			assertTrue(exception);

--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security.ui;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.201.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,
@@ -15,7 +15,7 @@ Import-Package: javax.crypto.spec,
  org.eclipse.osgi.util;version="[1.1.0,2.0.0)",
  org.osgi.framework,
  org.osgi.util.tracker;version="[1.3.3,2.0.0)"
-Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.0.0,2.0.0)",
+Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.3.0,2.0.0)",
  org.eclipse.equinox.preferences;bundle-version="[3.2.200,4.0.0)",
  org.eclipse.swt;bundle-version="[3.118.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",

--- a/bundles/org.eclipse.equinox.security.ui/pom.xml
+++ b/bundles/org.eclipse.equinox.security.ui/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security.ui</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.3.201-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/bundles/org.eclipse.equinox.security/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.security;singleton:=true
-Bundle-Version: 1.3.900.qualifier
+Bundle-Version: 1.3.901.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.equinox.internal.security.auth.AuthPlugin

--- a/bundles/org.eclipse.equinox.security/pom.xml
+++ b/bundles/org.eclipse.equinox.security/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.security</artifactId>
-  <version>1.3.900-SNAPSHOT</version>
+  <version>1.3.901-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/friends/IStorageConstants.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/friends/IStorageConstants.java
@@ -31,12 +31,12 @@ public interface IStorageConstants {
 	/**
 	 * Default cipher algorithm to use in secure storage
 	 */
-	public String DEFAULT_CIPHER = "PBEWithMD5AndDES"; //$NON-NLS-1$
+	public String DEFAULT_CIPHER = "PBEWithHmacSHA512AndAES_256"; //$NON-NLS-1$
 
 	/**
 	 * Default key factory algorithm to use in secure storage
 	 */
-	public String DEFAULT_KEY_FACTORY = "PBEWithMD5AndDES"; //$NON-NLS-1$
+	public String DEFAULT_KEY_FACTORY = "PBEWithHmacSHA512AndAES_256"; //$NON-NLS-1$
 
 	/**
 	 * Preference contains list of disabled password provider modules


### PR DESCRIPTION
move the default from weaker MD5/DES to a stronger SHA/AES which is available in JVMs.
PBEWithMD5AndDES -> PBEWithHmacSHA512AndAES_256

Refs: https://github.com/eclipse-equinox/equinox/pull/285

/cc @tjwatson 

